### PR TITLE
Small Updates

### DIFF
--- a/python_scripts/date_countdown.py
+++ b/python_scripts/date_countdown.py
@@ -22,9 +22,14 @@ if today < nextOccur:
   numberOfDays = (nextOccur - today).days
 
 elif today > nextOccur:
-  nextOccur = datetime.date(thisYear+1 , dateMonth , dateDay)
-  numberOfDays = (nextOccur - today).days
-  years = years + 1
+  if thisYear > dateYear + 1:
+    nextOccur = datetime.date(thisYear + 1 , dateMonth , dateDay)
+    numberOfDays = (nextOccur - today).days
+    years = years + 1
+  else:
+    nextOccur = datetime.date(dateYear , dateMonth , dateDay)
+    numberOfDays = (nextOccur - today).days
+    years = years + 1
 
 hass.states.set(sensorName , numberOfDays ,
   {

--- a/python_scripts/date_countdown.py
+++ b/python_scripts/date_countdown.py
@@ -31,11 +31,18 @@ elif today > nextOccur:
     numberOfDays = (nextOccur - today).days
     years = years + 1
 
+friendly_name = ''
+
+if type.lower() == 'birthday':
+  friendly_name = "{}'s {}".format(name , type)
+else:
+  friendly_name = "{} {}".format(name , type)
+
 hass.states.set(sensorName , numberOfDays ,
   {
     "icon" : "mdi:calendar-star" ,
     "unit_of_measurement" : "days" ,
-    "friendly_name" : "{}'s {}".format(name , type) ,
+    "friendly_name" : friendly_name,
     "nextoccur" : "{}/{}/{}".format(nextOccur.day , nextOccur.month , nextOccur.year) ,
     "years" : years
   }


### PR DESCRIPTION
Just made some small updates:

- If the date of event is more than 1 year in the future (like 2021 if current year is 2019), use the event date to calculate distance to event.
- add apostrophe to the friendly name of the sensor only if the event type is birthday. easy to change if desired.